### PR TITLE
[Fix] HttpOnly(true) 때문에 직접 cookie에 접근해 토큰 읽어오는 로직 제거

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -3,7 +3,6 @@ import axios, {
   AxiosResponse,
   AxiosError,
 } from "axios";
-import { getCookie } from "cookies-next";
 
 export const api = axios.create({
   baseURL: "https://api.urecastudycafe.store", // 백엔드 주소로 변경
@@ -48,15 +47,6 @@ api.interceptors.response.use(
     if (status === 401 && originalRequest && !originalRequest._retry) {
       originalRequest._retry = true; // 재시도 플래그 설정
       console.log("Access Token 만료 감지. 재발급 시도 중...");
-
-      // 쿠키에 Refresh Token이 있는지 확인 (Next.js 환경 가정)
-      if (!getCookie("refresh")) {
-        console.error("Refresh Token이 쿠키에 없습니다. 재로그인 필요.");
-        localStorage.removeItem("access");
-        // 💡 Next.js Router를 사용할 수 없으므로 window.location 사용
-        window.location.href = "/login";
-        return Promise.reject(error);
-      }
 
       try {
         // 토큰 재발급 요청 (Refresh Token은 자동으로 쿠키로 전송됨)

--- a/src/components/HeaderComponent.jsx
+++ b/src/components/HeaderComponent.jsx
@@ -9,15 +9,6 @@ export default function HeaderComponent() {
   const router = useRouter();
 
   useEffect(() => {
-    // 쿠키에서 access 가져오기
-    const access = Cookies.get("access");
-    const refresh = Cookies.get("refresh");
-
-    if (access) {
-      localStorage.setItem("access", access);
-      Cookies.remove("access");
-    }
-
     // 토큰 존재 여부로 로그인 상태 결정
     setIsLogin(!!localStorage.getItem("access"));
   }, []);


### PR DESCRIPTION

## 📝작업 내용

배포 환경 에러 발생으로 인한 백엔드 코드 변경에 맞추기 위해 프론트 코드 변경

<br/>

## 👀변경 사항

HeaderComponent.jsx
- cookie 값 직접 접근해 refreshToken 있는지 검사 X

api.ts
- 토큰 재발급시 값 직접 접근해 refreshToken 있는지 검사 X

<br/>

## #️⃣관련 이슈

Closes #70